### PR TITLE
Improve guestbook iframe loading resilience

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -645,6 +645,14 @@ a:hover {
   padding: 1.4rem;
   box-shadow: 3px 4px 10px rgba(60,40,10,0.12);
 }
+.guestbook-status {
+  margin-bottom: 0.9rem;
+  font-size: 0.86rem;
+  color: var(--text-secondary);
+}
+.guestbook-status a {
+  color: var(--accent-link);
+}
 .guestbook-frame {
   display: block;
   width: 100%;

--- a/js/app.js
+++ b/js/app.js
@@ -300,10 +300,15 @@
     const container = document.getElementById('guestbook-comments');
     container.innerHTML = '';
 
+    const status = document.createElement('div');
+    status.className = 'guestbook-status';
+    status.innerHTML = 'Loading guestbook… If it stays blank, <a href="https://ashnarrative.atabook.org/" target="_blank" rel="noopener noreferrer">open it in a new tab</a>.';
+    container.appendChild(status);
+
     const frame = document.createElement('iframe');
     frame.src = 'https://ashnarrative.atabook.org/';
     frame.className = 'guestbook-frame';
-    frame.loading = 'lazy';
+    frame.loading = 'eager';
     frame.title = 'Ash Narrative Atabook Guestbook';
     frame.referrerPolicy = 'strict-origin-when-cross-origin';
 
@@ -314,7 +319,22 @@
         <a href="https://ashnarrative.atabook.org/" target="_blank" rel="noopener noreferrer">ashnarrative.atabook.org</a>.
       </div>`;
 
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      status.innerHTML = fallbackHtml;
+    }, 7000);
+
+    frame.addEventListener('load', () => {
+      settled = true;
+      clearTimeout(timeout);
+      status.remove();
+    });
+
     frame.addEventListener('error', () => {
+      settled = true;
+      clearTimeout(timeout);
       container.innerHTML = fallbackHtml;
     });
 


### PR DESCRIPTION
### Motivation
- The Atabook-powered guestbook sometimes renders as a blank area when the embed stalls or is blocked, leaving users without guidance or a fallback link.
- Provide visible feedback and a reliable fallback so the Guestbook section never appears empty to visitors.

### Description
- Add a visible status block above the Atabook iframe with a direct-link fallback message to `https://ashnarrative.atabook.org/` so users can open the guestbook in a new tab if needed (`js/app.js`).
- Switch the guestbook iframe from `loading="lazy"` to `loading="eager"` so it begins initialization immediately when the Guestbook route is opened (`js/app.js`).
- Add timeout handling (7s) and `load`/`error` listeners to replace the loading message with a friendly fallback if the iframe does not settle, and to remove the status once the iframe loads successfully (`js/app.js`).
- Add minimal CSS for the new `.guestbook-status` element so the message and link match the site theme (`css/style.css`).

### Testing
- Launched a local server with `python3 -m http.server 4173` and navigated to `/#guestbook`, which served the updated guestbook UI successfully.
- Ran a headless Playwright script that opened `http://127.0.0.1:4173/#guestbook` and captured a screenshot saved as `artifacts/guestbook-fix.png`, confirming the status message and iframe were rendered.
- Verified the updated files and UI changes by inspecting the modified `js/app.js` and `css/style.css` and confirming the expected timeout and load/error behavior were present in the code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a1be6e3f9c8332bf14bfb9eadc3d69)