### PR TITLE
Add ASCII art/diagram blocks and post-writing guide

### DIFF
--- a/content/post-writing-guide.md
+++ b/content/post-writing-guide.md
@@ -1,0 +1,182 @@
+# AshNarrative post writing guide
+
+Use this as a quick reference when adding or editing posts in `content/`.
+
+## 1. Where posts live
+
+Each section has an `index.txt` and one `.txt` file per post.
+
+```text
+content/
+  lab-notes/
+    index.txt
+    my-post.txt
+  projects/
+    index.txt
+    my-project.txt
+  musings/
+    index.txt
+    my-thought.txt
+```
+
+Add the post filename **without** `.txt` to that section's `index.txt`:
+
+```text
+my-project
+another-project
+```
+
+## 2. Frontmatter
+
+Every post starts with metadata between `---` lines:
+
+```yaml
+---
+title: 8086 Assembly Programming
+date: 2026-07-24
+tags: [asm, 8086]
+excerpt: A short sentence shown on listing cards.
+cover: content/gallery/upload/example.png
+---
+```
+
+Notes:
+
+- `title` is shown at the top of the post.
+- `date` should use `YYYY-MM-DD`.
+- `tags` can be written as `[tag one, tag two]` or `tag one, tag two`.
+- `excerpt` is optional but recommended for post cards.
+- `cover` is optional.
+
+## 3. Content blocks
+
+After the frontmatter, write the post as blocks. A block starts with a marker like `[text]` or `[ascii]`.
+
+### Text
+
+```text
+[text]
+This is a normal paragraph.
+
+Blank lines create another paragraph inside the same text block.
+Inline formatting supports **bold**, *italic*, `inline code`, and [links](https://example.com).
+```
+
+### Headings
+
+```text
+[heading]
+My section title
+
+[heading]
+### Smaller heading
+```
+
+Use `[heading]` for section titles. Add `##` or `###` if you want to control heading size.
+
+### ASCII art and diagrams
+
+Use `[ascii]` for tables, circuit drawings, terminal layouts, memory maps, and anything where spaces must line up.
+
+```text
+[ascii]
++-------+------+
+| Box 0 | 0101 |
++-------+------+
+| Box 1 | 1110 |
++-------+------+
+```
+
+Tips for clean ASCII:
+
+- Put the whole drawing in **one** `[ascii]` block.
+- Do **not** put `[text]` before every line of the drawing.
+- Use spaces, not proportional alignment in normal text.
+- Very wide diagrams are okay; the site will keep the spacing and allow horizontal scrolling.
+- `[diagram]` also works as an alias for `[ascii]`.
+
+### Code
+
+Use `[code]` for source code snippets.
+
+```text
+[code]
+MOV AX, 0001h
+INT 21h
+```
+
+### LaTeX / math
+
+```text
+[latex]
+V = I R
+```
+
+Inline math can also be written in text blocks with `$V = IR$`.
+
+### Images
+
+```text
+[image]
+src: content/gallery/upload/example.png
+alt: Short description of the image
+caption: Optional caption shown below the image
+```
+
+### Quotes
+
+```text
+[quote]
+A short quote or note can go here.
+```
+
+### Lists
+
+```text
+[list]
+- First item
+- Second item
+- Third item
+```
+
+Numbered lists work too:
+
+```text
+[list]
+1. First step
+2. Second step
+3. Third step
+```
+
+### Divider
+
+```text
+[divider]
+```
+
+## 4. Minimal post template
+
+Copy this when making a new post:
+
+```text
+---
+title: My New Post
+date: 2026-07-24
+tags: [tag]
+excerpt: One sentence summary.
+---
+
+[text]
+Opening paragraph.
+
+[heading]
+First section
+
+[text]
+More writing here.
+
+[ascii]
++-----+
+| art |
++-----+
+```

--- a/content/projects/asm.txt
+++ b/content/projects/asm.txt
@@ -14,29 +14,19 @@ based on ChibiAkumas Tutorials
 Lesson 1:
 [text]
 Memory:
-[text]
+
+[ascii]
 +-------+------+
-[text]
 | Box 0 | 0101 |
-[text]
 +-------+------+
-[text]
 | Box 1 | 1110 |
-[text]
 +-------+------+
-[text]
 | Box 2 | 0001 |
-[text]
 +-------+------+
-[text]
       ...
-[text]
 +-----------+------+
-[text]
 | Box 65535 | 1010 |
-[text]
 +-----------+------+
-[text]
 
 Address      Data
 -------      ----
@@ -49,8 +39,10 @@ Address      Data
 65535        90
 
 
+[text]
 Address bus:
 
+[ascii]
 CPU
  │
  │ Address Bus
@@ -58,6 +50,7 @@ CPU
  ▼
 Memory
 
+[text]
 The cpu send the address over this wires. The memory responds with the data stored there.
 for Z80, it has a 16-bit address but --> 16 wires
 each wire can be either: 0 or 1

--- a/css/style.css
+++ b/css/style.css
@@ -603,6 +603,28 @@ a:hover {
   line-height: 1.65;
 }
 
+.post-body .block-ascii {
+  max-width: 100%;
+  margin: 1.2rem 0;
+  padding: 0.9rem 1rem;
+  overflow-x: auto;
+  border: 2px solid var(--border-color);
+  border-left: 5px solid var(--accent);
+  background: rgba(247, 240, 222, 0.72);
+  box-shadow: inset 0 0 0 1px rgba(160, 136, 64, 0.22);
+}
+
+.post-body .block-ascii pre {
+  display: inline-block;
+  min-width: 100%;
+  font-family: var(--font-mono);
+  font-size: 0.84rem;
+  line-height: 1.35;
+  color: var(--text-primary);
+  white-space: pre;
+  tab-size: 4;
+}
+
 .post-body .block-quote {
   border-left: 4px solid var(--border-color);
   border-top: 1px solid var(--border-color);

--- a/js/parser.js
+++ b/js/parser.js
@@ -25,6 +25,11 @@
  * [code]
  * console.log("hello");
  *
+ * [ascii]
+ * +-------+------+
+ * | Box 0 | 0101 |
+ * +-------+------+
+ *
  * [quote]
  * "Great Scott!" - Doc Brown
  *
@@ -56,7 +61,12 @@ const ContentParser = (() => {
       let value = line.slice(idx + 1).trim();
 
       if (key === 'tags') {
-        value = value.split(',').map(t => t.trim()).filter(Boolean);
+        value = value
+          .replace(/^\[/, '')
+          .replace(/\]$/, '')
+          .split(',')
+          .map(t => t.trim())
+          .filter(Boolean);
       }
       meta[key] = value;
     }
@@ -82,14 +92,21 @@ const ContentParser = (() => {
 
     for (let i = 1; i < parts.length; i += 3) {
       const type = parts[i];
-      const inline = (parts[i + 1] || '').trim();
-      const body = (parts[i + 2] || '').trim();
+      const inline = trimBlock(parts[i + 1] || '');
+      const body = trimBlock(parts[i + 2] || '');
       const content = inline ? (body ? inline + '\n' + body : inline) : body;
 
       blocks.push({ type, content });
     }
 
     return blocks;
+  }
+
+  /**
+   * Remove marker-separating blank lines without touching indentation.
+   */
+  function trimBlock(value) {
+    return value.replace(/^\n+/, '').replace(/\n+$/, '');
   }
 
   /**

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -48,6 +48,13 @@ const ContentRenderer = (() => {
   }
 
   /**
+   * Render ASCII art and diagrams with exact spacing preserved.
+   */
+  function renderAscii(content) {
+    return `<div class="block block-ascii"><pre>${escapeHtml(content)}</pre></div>`;
+  }
+
+  /**
    * Render a quote block
    */
   function renderQuote(content) {
@@ -96,6 +103,8 @@ const ContentRenderer = (() => {
         case 'latex':   return renderLatex(block.content);
         case 'image':   return renderImage(block.content);
         case 'code':    return renderCode(block.content);
+        case 'ascii':   return renderAscii(block.content);
+        case 'diagram': return renderAscii(block.content);
         case 'quote':   return renderQuote(block.content);
         case 'heading': return renderHeading(block.content);
         case 'list':    return renderList(block.content);
@@ -148,6 +157,7 @@ const ContentRenderer = (() => {
     renderLatex,
     renderImage,
     renderCode,
+    renderAscii,
     renderQuote,
     renderHeading,
     renderList,


### PR DESCRIPTION
### Motivation
- Preserve fixed-width ASCII art and diagrams in posts so tables, memory maps, and circuit drawings keep exact spacing and alignment.  
- Make it easier to author posts by documenting frontmatter and block syntax, including an explicit `ascii`/`diagram` block for monospaced art.  
- Improve frontmatter tag parsing and block trimming so lists and indented diagrams are parsed correctly.

### Description
- Add `renderAscii(content)` and treat `ascii` and `diagram` as block types in `js/renderer.js` so ASCII blocks are emitted as escaped `<pre>` inside a themed wrapper.  
- Update `js/parser.js` to preserve leading indentation inside blocks via a new `trimBlock()` helper and support bracket-style tags like `tags: [a, b]`.  
- Add `.post-body .block-ascii` CSS in `css/style.css` to style ASCII blocks with a monospaced font, preserved whitespace, themed border/background, and horizontal scrolling for wide diagrams.  
- Convert the assembly example `content/projects/asm.txt` to use `[ascii]` blocks for the memory table and address-bus diagram, and add `content/post-writing-guide.md` with authoring rules, examples, and a minimal post template.

### Testing
- Ran `node --check js/parser.js` and `node --check js/renderer.js`, both succeeded.  
- Ran Python assertions that verify the updated assembly post contains `[ascii]` blocks and that the new `content/post-writing-guide.md` exists and contains the ASCII guidance, and all assertions passed.  
- Started a local `python3 -m http.server` for visual testing, but browser/Playwright was not available in the environment so automated visual screenshot tests could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a635b9a52c883299ac3e5ee8bbd6358)