### PR TITLE
Add manual pagination for long posts

### DIFF
--- a/content/post-writing-guide.md
+++ b/content/post-writing-guide.md
@@ -154,6 +154,26 @@ Numbered lists work too:
 [divider]
 ```
 
+### Long post pages
+
+Use `[next-page]` to split one long post into multiple readable pages. The site will add **Previous page** and **Next page** buttons automatically, plus page numbers.
+
+```text
+[text]
+This appears on page 1.
+
+[next-page]
+
+[text]
+This appears on page 2.
+
+[next-page]
+
+[text]
+This appears on page 3.
+```
+
+
 ## 4. Minimal post template
 
 Copy this when making a new post:

--- a/css/style.css
+++ b/css/style.css
@@ -904,6 +904,14 @@ a:hover {
   border-color: var(--border-color);
   color: var(--text-secondary);
 }
+.post-pagination {
+  max-width: 680px;
+  justify-content: space-between;
+}
+.post-pagination .pagination-numbers {
+  justify-content: center;
+  flex-wrap: wrap;
+}
 
 /* ============================================================
    LOADING / EMPTY

--- a/js/app.js
+++ b/js/app.js
@@ -100,7 +100,7 @@
     } else if (route.section === 'webring') {
       renderWebring();
     } else if (route.slug) {
-      renderPost(route.section, route.slug);
+      renderPost(route.section, route.slug, route.page);
     } else if (sections[route.section]) {
       renderSection(route.section, route.page);
     } else {
@@ -495,13 +495,17 @@
   }
 
   // ── Single Post ───────────────────────────────────────────
-  async function renderPost(section, slug) {
+  async function renderPost(section, slug, page = 1) {
     const info = sections[section];
     contentEl.innerHTML = `<div class="loading">Loading post...</div>`;
 
     try {
       const raw = await fetchContent(`content/${section}/${slug}.txt`);
       const { meta, blocks } = ContentParser.parse(raw);
+      const pages = paginatePostBlocks(blocks);
+      const totalPages = pages.length;
+      const currentPage = Math.min(Math.max(page, 1), totalPages);
+      const currentBlocks = pages[currentPage - 1];
 
       let html = `
         <div class="post-view">
@@ -514,8 +518,9 @@
             </div>
           </div>
           <div class="post-body">
-            ${ContentRenderer.renderBlocks(blocks)}
+            ${ContentRenderer.renderBlocks(currentBlocks)}
           </div>
+          ${totalPages > 1 ? renderPostPageControls(section, slug, currentPage, totalPages) : ''}
         </div>`;
 
       contentEl.innerHTML = html;
@@ -533,6 +538,55 @@
           <div class="empty-state">Post not found: ${escapeHtml(slug)}</div>
         </div>`;
     }
+  }
+
+
+  function paginatePostBlocks(blocks) {
+    const pages = [[]];
+
+    blocks.forEach(block => {
+      if (block.type === 'next-page') {
+        if (pages[pages.length - 1].length > 0) {
+          pages.push([]);
+        }
+        return;
+      }
+
+      pages[pages.length - 1].push(block);
+    });
+
+    return pages.filter(pageBlocks => pageBlocks.length > 0).length
+      ? pages.filter(pageBlocks => pageBlocks.length > 0)
+      : [[]];
+  }
+
+  function renderPostPageControls(section, slug, currentPage, totalPages) {
+    let html = '<nav class="pagination post-pagination" aria-label="Post pages">';
+
+    if (currentPage > 1) {
+      html += `<a href="#${section}/${slug}?page=${currentPage - 1}" class="pagination-link pagination-prev">← Previous page</a>`;
+    } else {
+      html += '<span class="pagination-link pagination-prev disabled">← Previous page</span>';
+    }
+
+    html += '<span class="pagination-numbers">';
+    for (let i = 1; i <= totalPages; i++) {
+      if (i === currentPage) {
+        html += `<span class="pagination-link active" aria-current="page">${i}</span>`;
+      } else {
+        html += `<a href="#${section}/${slug}?page=${i}" class="pagination-link">${i}</a>`;
+      }
+    }
+    html += '</span>';
+
+    if (currentPage < totalPages) {
+      html += `<a href="#${section}/${slug}?page=${currentPage + 1}" class="pagination-link pagination-next">Next page →</a>`;
+    } else {
+      html += '<span class="pagination-link pagination-next disabled">Next page →</span>';
+    }
+
+    html += '</nav>';
+    return html;
   }
 
   // ── Gallery ───────────────────────────────────────────────

--- a/js/parser.js
+++ b/js/parser.js
@@ -81,23 +81,28 @@ const ContentParser = (() => {
     const blocks = [];
     if (!bodyRaw) return blocks;
 
-    // Split on block markers: [type] or [type] inline-content
-    const parts = bodyRaw.split(/^\[(\w+)\]\s*(.*)?$/m);
+    // Block markers look like [type] or [type-name] inline-content.
+    const markerRe = /^\[([\w-]+)\][^\S\r\n]*(.*)?$/gm;
+    const markers = Array.from(bodyRaw.matchAll(markerRe));
 
-    // parts[0] = text before first marker (if any)
-    // then groups of 3: [matchedType, inlineContent, blockBody]
-    if (parts[0] && parts[0].trim()) {
-      blocks.push({ type: 'text', content: parts[0].trim() });
+    if (markers.length === 0) {
+      if (bodyRaw.trim()) blocks.push({ type: 'text', content: bodyRaw.trim() });
+      return blocks;
     }
 
-    for (let i = 1; i < parts.length; i += 3) {
-      const type = parts[i];
-      const inline = trimBlock(parts[i + 1] || '');
-      const body = trimBlock(parts[i + 2] || '');
+    const leadingText = bodyRaw.slice(0, markers[0].index).trim();
+    if (leadingText) blocks.push({ type: 'text', content: leadingText });
+
+    markers.forEach((marker, index) => {
+      const type = marker[1].toLowerCase();
+      const inline = trimBlock(marker[2] || '');
+      const bodyStart = marker.index + marker[0].length;
+      const bodyEnd = index + 1 < markers.length ? markers[index + 1].index : bodyRaw.length;
+      const body = trimBlock(bodyRaw.slice(bodyStart, bodyEnd));
       const content = inline ? (body ? inline + '\n' + body : inline) : body;
 
       blocks.push({ type, content });
-    }
+    });
 
     return blocks;
   }


### PR DESCRIPTION
### Motivation
- Provide a simple way for authors to split long posts into multiple readable pages using an inline marker and reuse the existing site pagination UI.

### Description
- Extend the content parser to recognize hyphenated block markers (e.g. `[next-page]`) using a marker regex and `matchAll`, and normalize block types to lower-case so separator markers are parsed as their own blocks (`js/parser.js`).
- Add post-level pagination that slices a post's parsed blocks into pages with a `paginatePostBlocks` helper and accept `?page=` in post routes so a single post can render a specific page (`js/app.js`).
- Render Previous/Next and numbered page links for multi-page posts via `renderPostPageControls`, and reuse existing pagination styling while adding `.post-pagination` tweaks (`js/app.js`, `css/style.css`).
- Document usage of the `[next-page]` marker in the post-writing guide and include an example (`content/post-writing-guide.md`).

### Testing
- Checked JavaScript syntax with `node --check js/parser.js && node --check js/renderer.js && node --check js/app.js` and the checks passed. 
- Ran a parser smoke test via a small Node VM script that parsed a sample post containing `[next-page]` and verified blocks are split correctly, and the test passed. 
- Started a local static server with `python3 -m http.server 4173` and verified the server responded with `curl -I`, which succeeded. 
- Browser screenshot/testing tools were not available in the environment, so interactive visual verification (headless browser) was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63a8ae70c483299d8be7bff1bf00b8)